### PR TITLE
fix site_setting disable_emails arguments

### DIFF
--- a/responses/admin/site_settings.json
+++ b/responses/admin/site_settings.json
@@ -2342,10 +2342,24 @@
       "setting": "disable_emails",
       "description": "Prevent Discourse from sending any kind of emails",
       "default": "false",
-      "type": "bool",
-      "value": "false",
+      "type": "enum",
+      "value": "yes",
       "category": "email",
-      "preview": null
+      "preview": null,
+      "valid_values": [
+        {
+          "name": "yes",
+          "value": "yes"
+        },
+        {
+          "name": "no",
+          "value": "no"
+        },
+        {
+          "name": "non-staff",
+          "value": "non-staff"
+        }
+      ]
     },
     {
       "setting": "strip_images_from_short_emails",

--- a/swagger.json
+++ b/swagger.json
@@ -15004,7 +15004,7 @@
                 "automatically_download_gravatars": {
                   "type": "boolean",
                   "example": true,
-                  "description": ""
+                  "description": "\"Download Gravatars for users upon account creation or email change.\"\n"
                 }
               }
             }

--- a/swagger.json
+++ b/swagger.json
@@ -13478,8 +13478,13 @@
               ],
               "properties": {
                 "disable_emails": {
-                  "type": "boolean",
-                  "example": false,
+                  "type": "string",
+                  "enum": [
+                    "yes",
+                    "no",
+                    "non-staff"
+                  ],
+                  "example": "yes",
                   "description": "Prevent Discourse from sending any kind of emails\n"
                 }
               }
@@ -14999,7 +15004,7 @@
                 "automatically_download_gravatars": {
                   "type": "boolean",
                   "example": true,
-                  "description": "\"Download Gravatars for users upon account creation or email change.\"\n"
+                  "description": ""
                 }
               }
             }

--- a/swagger.yml
+++ b/swagger.yml
@@ -7129,6 +7129,7 @@ paths:
                 type: boolean
                 example: true
                 description: |
+                  "Download Gravatars for users upon account creation or email change."
       responses:
         '200':
           description: |

--- a/swagger.yml
+++ b/swagger.yml
@@ -6055,8 +6055,12 @@ paths:
               - disable_emails
             properties:
               disable_emails:
-                type: boolean
-                example: false
+                type: string
+                enum:
+                  - yes
+                  - no
+                  - non-staff
+                example: "yes"
                 description: |
                   Prevent Discourse from sending any kind of emails
       responses:
@@ -7125,7 +7129,6 @@ paths:
                 type: boolean
                 example: true
                 description: |
-                  "Download Gravatars for users upon account creation or email change."
       responses:
         '200':
           description: |


### PR DESCRIPTION
API changed from boolean to enum:

now you can use 'yes' (instead of true), 'no' (instead of false),
and 'non-staff' to forbid Discourse from sending emails except
for Staff.