### PR TITLE
Add embed_url to topic create method

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4322,6 +4322,10 @@
                   },
                   "created_at": {
                     "type": "string"
+                  },
+                  "embed_url": {
+                    "type": "string",
+                    "description": "Provide a URL from a remote system to associate a forum topic with that URL, typically for using Discourse as a comments system for an external blog."
                   }
                 },
                 "required": [

--- a/openapi.yml
+++ b/openapi.yml
@@ -3055,6 +3055,9 @@ paths:
                   example: private_message
                 created_at:
                   type: string
+                embed_url:
+                  type: string
+                  description: Provide a URL from a remote system to associate a forum topic with that URL, typically for using Discourse as a comments system for an external blog.
               required:
               - raw
   "/posts/{id}.json":


### PR DESCRIPTION
Since the `POST /topics.json` method accepts `embed_url`, this PR adds that to the documentation.

This would have saved me a lot of headache in a blog comment migration project as [documented on the meta forum](https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963/417?u=aaronpk).