### PR TITLE
FIX: run lefthook commands concurrently

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,5 +1,5 @@
 pre-commit:
-  paralel: true
+  parallel: true
   commands:
     openapi-lint:
       run: node tojson.js && npx @redocly/openapi-cli lint openapi.json


### PR DESCRIPTION
**PR Summary**:
I noticed that there is a typo in the lefthook config (`paralel` -> `parallel`). Even though there is currently only one command, I believe implementing this change can potentially save considerable debugging time for someone in the future.