### PR TITLE
DEV: Add auto_track param to POST /posts.json

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1005,7 +1005,34 @@
                           "require_reply_approval": null,
                           "require_topic_approval": null
                         },
-                        "category_localizations": [],
+                        "category_localizations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "The unique identifier for an existing localization. Must be included otherwise the record will be deleted."
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale for the localization, e.g., 'en', 'zh_CN'. Locale should be in the list of SiteSetting.content_localization_supported_locales."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The name of the category in the specified locale."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "The description excerpt of the category in the specified locale."
+                              }
+                            },
+                            "required": [
+                              "locale",
+                              "name"
+                            ]
+                          }
+                        },
                         "read_only_banner": {
                           "type": [
                             "string",
@@ -1721,7 +1748,34 @@
                           "require_reply_approval": null,
                           "require_topic_approval": null
                         },
-                        "category_localizations": [],
+                        "category_localizations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "The unique identifier for an existing localization. Must be included otherwise the record will be deleted."
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale for the localization, e.g., 'en', 'zh_CN'. Locale should be in the list of SiteSetting.content_localization_supported_locales."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The name of the category in the specified locale."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "The description excerpt of the category in the specified locale."
+                              }
+                            },
+                            "required": [
+                              "locale",
+                              "name"
+                            ]
+                          }
+                        },
                         "read_only_banner": {
                           "type": [
                             "string",
@@ -2435,7 +2489,34 @@
                           "require_reply_approval": null,
                           "require_topic_approval": null
                         },
-                        "category_localizations": [],
+                        "category_localizations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "The unique identifier for an existing localization. Must be included otherwise the record will be deleted."
+                              },
+                              "locale": {
+                                "type": "string",
+                                "description": "The locale for the localization, e.g., 'en', 'zh_CN'. Locale should be in the list of SiteSetting.content_localization_supported_locales."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The name of the category in the specified locale."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "The description excerpt of the category in the specified locale."
+                              }
+                            },
+                            "required": [
+                              "locale",
+                              "name"
+                            ]
+                          }
+                        },
                         "read_only_banner": {
                           "type": [
                             "string",
@@ -4985,6 +5066,10 @@
                   "external_id": {
                     "type": "string",
                     "description": "Provide an external_id from a remote system to associate\na forum topic with that id."
+                  },
+                  "auto_track": {
+                    "type": "boolean",
+                    "description": "If false, the user will not track the topic. By default, the user will track the topic."
                   }
                 },
                 "required": [

--- a/openapi.yml
+++ b/openapi.yml
@@ -3572,6 +3572,10 @@ paths:
                   type: string
                   description: Provide an external_id from a remote system to associate
                     a forum topic with that id.
+                auto_track:
+                  type: boolean
+                  description: If false, the user will not track the topic. By default,
+                    the user will track the topic.
               required:
               - raw
   "/posts/{id}.json":


### PR DESCRIPTION
This PR adds `auto_track` to /posts.json and rectifies a schema issue from an earlier PR.

Related: 
- https://github.com/discourse/discourse/pull/34597
- https://github.com/discourse/discourse_api_docs/pull/137