### PR TITLE
DEV: Update workflow to use version 5 of create-pull-request

### DIFF
--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -80,7 +80,7 @@ jobs:
           npm install && npm run tojson
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v4.0.4
+        uses: peter-evans/create-pull-request@v5
         with:
           path: discourse_api_docs
           add-paths: "openapi.yml,openapi.json"


### PR DESCRIPTION
Version 5 of the create-pull-request action has been updated to use the new
environment file approach (GITHUB_OUTPUT) instead of the deprecated set-output
command.

This changes fixes the deprecation warning we are setting for set-output
