### PR TITLE
ci: add API drift check on openapi.json

### DIFF
--- a/.github/workflows/api-schema-check.yml
+++ b/.github/workflows/api-schema-check.yml
@@ -1,0 +1,21 @@
+name: API Schema Check
+
+on:
+  pull_request:
+    paths:
+      - 'openapi.json'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: delimit-ai/delimit-action@afa76ce3d1caa90a8de6bfd038471af672f60e90 # v1.11.3
+        with:
+          spec: openapi.json


### PR DESCRIPTION
**Optional advisory CI check for semantic drift in `openapi.json`**

Posting this as a small optional addition to sit alongside `validate_pr.yml`. The swagger-validator step there catches structural problems; this one would catch the class of change where the document stays valid OpenAPI but the response shape moves under SDK consumers.

Concretely, between commits c8d216f2 (early January) and 83610126 (April 23) four field renames landed in the response of `POST /tag_groups.json`:

- `tag_names` removed; replaced with `tags`
- `parent_tag_name` removed; replaced with `parent_tag`

Both pairs validate cleanly in OpenAPI 3.1.0, so they parsed fine through `validate_pr.yml`. A plugin or SDK consumer reading `tag_names` against the new spec would silently get `undefined` from that point forward.

**What this PR adds**

A single workflow file (`.github/workflows/api-schema-check.yml`) that runs a structural diff on `openapi.json` against the PR base and posts a comment if it flags a breaking change. Advisory-only: no `fail-on`, no required check, doesn't block any auto-PR. The Action is pinned by commit SHA rather than a floating tag.

If the shape isn't useful or the scope is wrong, happy to revise or close.
